### PR TITLE
tsnd watcher doesn't work on Windows

### DIFF
--- a/containers/development/api/.vscode/settings.json
+++ b/containers/development/api/.vscode/settings.json
@@ -1,4 +1,12 @@
 {
+    "emeraldwalk.runonsave": {
+        "commands": [
+            {
+                "match": "\\.ts$",
+                "cmd": "touch -m .watch"
+            }
+        ]
+    },
     "files.watcherExclude": {
         "**/.cache/**": true,
         "**/.cache/**/**": true,

--- a/containers/development/api/Dockerfile
+++ b/containers/development/api/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "shell '/bin/bash'" > /home/node/.screenrc
 ENV NODE_ENV=development
 ENV PATH=/home/node/node_modules/.bin:$PATH
 WORKDIR /home/node
-RUN npm install --only=development
+RUN npm install --only=development && touch ./.watch
 COPY --chown=node:node .vscode .vscode/
 COPY --chown=node:node .eslintrc.json ./
 COPY --chown=node:node .prettierrc.json ./
@@ -31,7 +31,7 @@ COPY --chown=node:node cucumberHtmlReporter.mjs ./
 COPY --chown=node:node jest.config.js ./
 COPY --chown=node:node stryker.conf.json ./
 COPY --chown=node:node typedoc.json ./
-CMD ["tsnd", "--transpile-only", "app/src/index.ts"]
+CMD ["tsnd", "--transpile-only", "--watch=./.watch", "app/src/index.ts"]
 
 FROM dev as update
 WORKDIR /home/node

--- a/containers/development/api/package.json
+++ b/containers/development/api/package.json
@@ -8,7 +8,8 @@
         "lint": "prettier --write 'app/acceptanceTests/steps/**/**' 'app/src/**/**' && eslint --fix 'app/acceptanceTests/steps/**/**' 'app/src/**/**' && echo 'All files passed!'",
         "unitTests": "jest --detectOpenHandles",
         "mutationTests": "stryker run",
-        "acceptanceTests": "mkdir --parents app/output/acceptance/html; mkdir --parents app/output/acceptance/json;cucumber-js; node cucumberHtmlReporter.mjs"
+        "acceptanceTests": "mkdir --parents app/output/acceptance/html; mkdir --parents app/output/acceptance/json;cucumber-js; node cucumberHtmlReporter.mjs",
+        "restartServer": "touch -m .watch"
     },
     "main": "app/www/index.js",
     "dependencies": {},


### PR DESCRIPTION

Add script to manually restart.

Add script to an extension that runs on file save.